### PR TITLE
set default function-name and domain-suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Lamux is a HTTP multiplexer for AWS Lambda Function aliases.
 ## Usage
 
 ```console
-Usage: lamux --function-name=STRING --domain-suffix=STRING [flags]
+Usage: lamux [flags]
 
 Flags:
-  -h, --help                    Show context-sensitive help.
-      --port=8080               Port to listen on ($LAMUX_PORT)
-      --function-name=STRING    Name of the Lambda function to proxy ($LAMUX_FUNCTION_NAME)
-      --domain-suffix=STRING    Domain suffix to accept requests for ($LAMUX_DOMAIN_SUFFIX)
-      --upstream-timeout=30s    Timeout for upstream requests ($LAMUX_UPSTREAM_TIMEOUT)
+  -h, --help                           Show context-sensitive help.
+      --port=8080                      Port to listen on ($LAMUX_PORT)
+      --function-name="*"              Name of the Lambda function to proxy ($LAMUX_FUNCTION_NAME)
+      --domain-suffix="localdomain"    Domain suffix to accept requests for ($LAMUX_DOMAIN_SUFFIX)
+      --upstream-timeout=30s           Timeout for upstream requests ($LAMUX_UPSTREAM_TIMEOUT)
 ```
 
 Lamux runs an HTTP server that listens on a specified port and forwards requests to a specified Lambda function aliases. The Lambda function alias is identified by its name, and the domain suffix is used to determine which requests should be forwarded to it.

--- a/config.go
+++ b/config.go
@@ -15,8 +15,8 @@ var functionNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
 type Config struct {
 	Port            int           `help:"Port to listen on" default:"8080" env:"LAMUX_PORT" name:"port"`
-	FunctionName    string        `help:"Name of the Lambda function to proxy" required:"" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
-	DomainSuffix    string        `help:"Domain suffix to accept requests for" required:"" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
+	FunctionName    string        `help:"Name of the Lambda function to proxy" default:"*" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
+	DomainSuffix    string        `help:"Domain suffix to accept requests for" default:"localdomain" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
 	UpstreamTimeout time.Duration `help:"Timeout for upstream requests" default:"30s" env:"LAMUX_UPSTREAM_TIMEOUT" name:"upstream-timeout"`
 }
 

--- a/lamux.go
+++ b/lamux.go
@@ -81,6 +81,7 @@ func Run(ctx context.Context) error {
 	var mux = http.NewServeMux()
 	mux.HandleFunc("/", l.wrapHandler(l.handleProxy))
 	addr := fmt.Sprintf(":%d", cfg.Port)
+	slog.Info("listening", "addr", addr, "function_name", cfg.FunctionName, "domain_suffix", cfg.DomainSuffix)
 
 	if ridge.AsLambdaExtension() {
 		ec, err := extensions.NewClient()


### PR DESCRIPTION
Set default function-name to '*' and domain-suffix to 'localdomain'.