### PR TITLE
resolve account id on runtime

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,11 +1,20 @@
 package lamux
 
+import (
+	"context"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
 type LambdaClient lambdaClient
 
-func (l *Lamux) SetClient(client LambdaClient) {
+func (l *Lamux) SetTestClient(client LambdaClient) {
+	l.awsCfg = aws.Config{}
+	l.SetAccountID("123456789012")
 	l.lambdaClient = client
 }
 
-func (l *Lamux) SetAccountID(accountID string) {
-	l.accountID = accountID
+func (l *Lamux) HandleProxy(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return l.handleProxy(ctx, w, r)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.62.0
 	github.com/aws/smithy-go v1.21.0
 	github.com/fujiwara/lambda-extensions v0.0.7
-	github.com/fujiwara/ridge v0.11.3
+	github.com/fujiwara/ridge v0.12.0
 	github.com/mashiike/go-otel-json-exporters/otlptracejson v0.0.0-20240925062218-f13fdc2ad62e
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0
 	go.opentelemetry.io/otel v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fujiwara/lambda-extensions v0.0.7 h1:UZYg4mVzAHdfaMMi9PBlv6P3h8Pyi+27oKwN99dZ0NY=
 github.com/fujiwara/lambda-extensions v0.0.7/go.mod h1:yc//D6j1tC/gOWwJ8fhnngLjo0yMIJqagHHQf8BTx5Y=
-github.com/fujiwara/ridge v0.11.3 h1:5Sz/3AgCCZNY5+IWiymFA9eFgdL1HLBMxHWtkXPy1co=
-github.com/fujiwara/ridge v0.11.3/go.mod h1:FUIBF8ZHZ2BpGp14b4oMbAiESQIldmtlJ1WAwt8TUbI=
+github.com/fujiwara/ridge v0.12.0 h1:FfNzZjvNR3jP94YPUYA0JcNmslNofLkNOkSnuzNlqm0=
+github.com/fujiwara/ridge v0.12.0/go.mod h1:FUIBF8ZHZ2BpGp14b4oMbAiESQIldmtlJ1WAwt8TUbI=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
This pull request introduces several changes to the `lamux` package, focusing on improving concurrency handling, enhancing functionality, and updating dependencies. The key changes include adding a mutex for thread safety, introducing new methods for handling AWS Lambda proxy requests, and updating test cases to match the new functionality.

### Concurrency Improvements:
* Added a `sync.Mutex` to the `Lamux` struct to ensure thread-safe operations. (`[lamux.goR38](diffhunk://#diff-c92a92f76bfdce5571d97801d9fc5f6b94da071f357f36068394dbf9dea1f6cdR38)`)

### New Functionality:
* Introduced `HandleProxy` and `resolveAccountIDOnRuntime` methods to handle AWS Lambda proxy requests and resolve the account ID at runtime. (`[[1]](diffhunk://#diff-0a6bbfea82155affe47f93238c073d7a71b95d26e602c63f3e18fa2b5c8d1c16R3-R19)`, `[[2]](diffhunk://#diff-c92a92f76bfdce5571d97801d9fc5f6b94da071f357f36068394dbf9dea1f6cdR210-R232)`)
* Modified the `SetAccountID` method to use the newly added mutex for thread safety. (`[lamux.goR60-R78](diffhunk://#diff-c92a92f76bfdce5571d97801d9fc5f6b94da071f357f36068394dbf9dea1f6cdR60-R78)`)

### Dependency Updates:
* Updated `github.com/fujiwara/ridge` dependency from version `v0.11.3` to `v0.12.0`. (`[go.modL15-R15](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L15-R15)`)

### Test Enhancements:
* Updated test cases to use the new `SetTestClient` method and added a new test for the `HandleProxy` method. (`[[1]](diffhunk://#diff-ef09012f4b5247a451be8776dace24c006785a8eafe091c463cf23a4b58e5cc3R6-R8)`, `[[2]](diffhunk://#diff-ef09012f4b5247a451be8776dace24c006785a8eafe091c463cf23a4b58e5cc3L133-R136)`, `[[3]](diffhunk://#diff-ef09012f4b5247a451be8776dace24c006785a8eafe091c463cf23a4b58e5cc3R154-R178)`)

### Import Additions:
* Added necessary imports in `export_test.go` and `lamux.go` for new functionality. (`[[1]](diffhunk://#diff-0a6bbfea82155affe47f93238c073d7a71b95d26e602c63f3e18fa2b5c8d1c16R3-R19)`, `[[2]](diffhunk://#diff-c92a92f76bfdce5571d97801d9fc5f6b94da071f357f36068394dbf9dea1f6cdR17)`)