### PR TITLE
Add --[no-]error-details option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Flags:
       --function-name="*"                 Name of the Lambda function to proxy ($LAMUX_FUNCTION_NAME)
       --domain-suffix="localdomain"       Domain suffix to accept requests for ($LAMUX_DOMAIN_SUFFIX)
       --upstream-timeout=30s              Timeout for upstream requests ($LAMUX_UPSTREAM_TIMEOUT)
+      --error-detail-hiding               Prevent showing error details ($LAMUX_ERROR_DETAIL_HIDING)
       --version                           Show version information
       --trace-insecure                    Disable TLS for Otel trace endpoint ($OTEL_EXPORTER_OTLP_INSECURE)
       --trace-protocol="http/protobuf"    Otel trace protocol ($OTEL_EXPORTER_OTLP_PROTOCOL)
@@ -161,6 +162,10 @@ Domain suffix to accept requests for. This setting is required.
 Timeout for upstream requests. Default is `30s`.
 
 This setting is affected by the Lambda function timeout. If the Lambda function timeout is less than the `--upstream-timeout`, it will time out before the `--upstream-timeout`.
+
+### `--error-detail-hiding` (`$LAMUX_ERROR_DETAIL_HIDING`)
+
+Prevent showing error details. Default is `false`.
 
 
 ### OpenTelemetry tracing support

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Flags:
       --function-name="*"                 Name of the Lambda function to proxy ($LAMUX_FUNCTION_NAME)
       --domain-suffix="localdomain"       Domain suffix to accept requests for ($LAMUX_DOMAIN_SUFFIX)
       --upstream-timeout=30s              Timeout for upstream requests ($LAMUX_UPSTREAM_TIMEOUT)
-      --error-detail-hiding               Prevent showing error details ($LAMUX_ERROR_DETAIL_HIDING)
+      --[no-]error-details                Include detailed errors in the response ($LAMUX_ERROR_DETAILS)
       --version                           Show version information
       --trace-insecure                    Disable TLS for Otel trace endpoint ($OTEL_EXPORTER_OTLP_INSECURE)
       --trace-protocol="http/protobuf"    Otel trace protocol ($OTEL_EXPORTER_OTLP_PROTOCOL)
@@ -163,9 +163,9 @@ Timeout for upstream requests. Default is `30s`.
 
 This setting is affected by the Lambda function timeout. If the Lambda function timeout is less than the `--upstream-timeout`, it will time out before the `--upstream-timeout`.
 
-### `--error-detail-hiding` (`$LAMUX_ERROR_DETAIL_HIDING`)
+### `--error-details` (`$LAMUX_ERROR_DETAILS`)
 
-Prevent showing error details. Default is `false`.
+Include detailed errors in the response. Default is `true`
 
 
 ### OpenTelemetry tracing support

--- a/config.go
+++ b/config.go
@@ -14,11 +14,12 @@ var aliasRegexp = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 var functionNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
 type Config struct {
-	Port            int           `help:"Port to listen on" default:"8080" env:"LAMUX_PORT" name:"port"`
-	FunctionName    string        `help:"Name of the Lambda function to proxy" default:"*" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
-	DomainSuffix    string        `help:"Domain suffix to accept requests for" default:"localdomain" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
-	UpstreamTimeout time.Duration `help:"Timeout for upstream requests" default:"30s" env:"LAMUX_UPSTREAM_TIMEOUT" name:"upstream-timeout"`
-	Version         bool          `help:"Show version information" name:"version"`
+	Port              int           `help:"Port to listen on" default:"8080" env:"LAMUX_PORT" name:"port"`
+	FunctionName      string        `help:"Name of the Lambda function to proxy" default:"*" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
+	DomainSuffix      string        `help:"Domain suffix to accept requests for" default:"localdomain" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
+	UpstreamTimeout   time.Duration `help:"Timeout for upstream requests" default:"30s" env:"LAMUX_UPSTREAM_TIMEOUT" name:"upstream-timeout"`
+	ErrorDetailHiding bool          `help:"Prevent showing error details" default:"false" env:"LAMUX_ERROR_DETAIL_HIDING" name:"error-detail-hiding"`
+	Version           bool          `help:"Show version information" name:"version"`
 
 	TraceConfig
 }

--- a/config.go
+++ b/config.go
@@ -14,12 +14,12 @@ var aliasRegexp = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 var functionNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
 type Config struct {
-	Port              int           `help:"Port to listen on" default:"8080" env:"LAMUX_PORT" name:"port"`
-	FunctionName      string        `help:"Name of the Lambda function to proxy" default:"*" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
-	DomainSuffix      string        `help:"Domain suffix to accept requests for" default:"localdomain" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
-	UpstreamTimeout   time.Duration `help:"Timeout for upstream requests" default:"30s" env:"LAMUX_UPSTREAM_TIMEOUT" name:"upstream-timeout"`
-	ErrorDetailHiding bool          `help:"Prevent showing error details" default:"false" env:"LAMUX_ERROR_DETAIL_HIDING" name:"error-detail-hiding"`
-	Version           bool          `help:"Show version information" name:"version"`
+	Port            int           `help:"Port to listen on" default:"8080" env:"LAMUX_PORT" name:"port"`
+	FunctionName    string        `help:"Name of the Lambda function to proxy" default:"*" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
+	DomainSuffix    string        `help:"Domain suffix to accept requests for" default:"localdomain" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
+	UpstreamTimeout time.Duration `help:"Timeout for upstream requests" default:"30s" env:"LAMUX_UPSTREAM_TIMEOUT" name:"upstream-timeout"`
+	ErrorDetails    bool          `help:"Include detailed errors in the response" default:"true" env:"LAMUX_ERROR_DETAILS" name:"error-details" negatable:""`
+	Version         bool          `help:"Show version information" name:"version"`
 
 	TraceConfig
 }

--- a/export_test.go
+++ b/export_test.go
@@ -17,3 +17,7 @@ func (l *Lamux) SetTestClient(client LambdaClient) {
 func (l *Lamux) HandleProxy(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	return l.handleProxy(ctx, w, r)
 }
+
+func (l *Lamux) WrapHandler(h handlerFunc) http.HandlerFunc {
+	return l.wrapHandler(h)
+}

--- a/lamux.go
+++ b/lamux.go
@@ -146,10 +146,10 @@ func (l *Lamux) wrapHandler(h handlerFunc) http.HandlerFunc {
 				slog.ErrorContext(ctx, "request", "status", http.StatusInternalServerError, "error", err)
 				code = http.StatusInternalServerError
 			}
-			if l.Config.ErrorDetailHiding {
-				http.Error(w, fmt.Sprintf("%d %s", code, http.StatusText(code)), code)
-			} else {
+			if l.Config.ErrorDetails {
 				http.Error(w, err.Error(), code)
+			} else {
+				http.Error(w, fmt.Sprintf("%d %s", code, http.StatusText(code)), code)
 			}
 			return
 		}

--- a/lamux.go
+++ b/lamux.go
@@ -146,7 +146,11 @@ func (l *Lamux) wrapHandler(h handlerFunc) http.HandlerFunc {
 				slog.ErrorContext(ctx, "request", "status", http.StatusInternalServerError, "error", err)
 				code = http.StatusInternalServerError
 			}
-			http.Error(w, err.Error(), code)
+			if l.Config.ErrorDetailHiding {
+				http.Error(w, fmt.Sprintf("%d %s", code, http.StatusText(code)), code)
+			} else {
+				http.Error(w, err.Error(), code)
+			}
 			return
 		}
 		slog.InfoContext(ctx, "response", "status", http.StatusOK)

--- a/lamux_test.go
+++ b/lamux_test.go
@@ -174,12 +174,12 @@ func TestProxy(t *testing.T) {
 }
 
 type wrapHandlerTestCase struct {
-	name       string
-	hideError  bool
-	client     *mockClient
-	alias      string
-	expectCode int
-	expectBody string
+	name           string
+	noErrorDetails bool
+	client         *mockClient
+	alias          string
+	expectCode     int
+	expectBody     string
 }
 
 var wrapHandlerTestCases = []wrapHandlerTestCase{
@@ -209,10 +209,10 @@ var wrapHandlerTestCases = []wrapHandlerTestCase{
 			code: 200,
 			body: "OK",
 		},
-		alias:      "notfound",
-		hideError:  true,
-		expectCode: 404,
-		expectBody: "404 Not Found\n",
+		alias:          "notfound",
+		noErrorDetails: true,
+		expectCode:     404,
+		expectBody:     "404 Not Found\n",
 	},
 }
 
@@ -220,10 +220,10 @@ func TestWrapHandler(t *testing.T) {
 	for _, tc := range wrapHandlerTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			app, err := lamux.NewLamux(&lamux.Config{
-				FunctionName:      "test-func",
-				DomainSuffix:      "example.net",
-				UpstreamTimeout:   time.Second,
-				ErrorDetailHiding: tc.hideError,
+				FunctionName:    "test-func",
+				DomainSuffix:    "example.net",
+				UpstreamTimeout: time.Second,
+				ErrorDetails:    !tc.noErrorDetails,
 			})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/lamux_test.go
+++ b/lamux_test.go
@@ -18,6 +18,7 @@ import (
 
 type mockClient struct {
 	code          int32
+	body          string
 	functionError *string
 	latency       time.Duration
 }
@@ -51,7 +52,7 @@ func (m *mockClient) Invoke(ctx context.Context, input *lambda.InvokeInput, optF
 		FunctionError:   m.functionError,
 		ExecutedVersion: aws.String("1"),
 		LogResult:       aws.String("dummy"),
-		Payload:         []byte(fmt.Sprintf(`{"statusCode":%d}`, m.code)),
+		Payload:         []byte(fmt.Sprintf(`{"statusCode":%d,"body":"%s"}`, m.code, m.body)),
 	}, nil
 }
 
@@ -169,5 +170,79 @@ func TestProxy(t *testing.T) {
 	}
 	if e, a := http.StatusOK, w.Code; e != a {
 		t.Errorf("expect %d, got %d", e, a)
+	}
+}
+
+type wrapHandlerTestCase struct {
+	name       string
+	hideError  bool
+	client     *mockClient
+	alias      string
+	expectCode int
+	expectBody string
+}
+
+var wrapHandlerTestCases = []wrapHandlerTestCase{
+	{
+		name: "invoke success",
+		client: &mockClient{
+			code: 200,
+			body: "OK",
+		},
+		alias:      "test",
+		expectCode: 200,
+		expectBody: "OK",
+	},
+	{
+		name: "invoke error not found alias",
+		client: &mockClient{
+			code: 200,
+			body: "OK",
+		},
+		alias:      "notfound",
+		expectCode: 404,
+		expectBody: "failed to invoke: ResourceNotFoundException: Resource not found\n",
+	},
+	{
+		name: "invoke error not found alias with hide error",
+		client: &mockClient{
+			code: 200,
+			body: "OK",
+		},
+		alias:      "notfound",
+		hideError:  true,
+		expectCode: 404,
+		expectBody: "404 Not Found\n",
+	},
+}
+
+func TestWrapHandler(t *testing.T) {
+	for _, tc := range wrapHandlerTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			app, err := lamux.NewLamux(&lamux.Config{
+				FunctionName:      "test-func",
+				DomainSuffix:      "example.net",
+				UpstreamTimeout:   time.Second,
+				ErrorDetailHiding: tc.hideError,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			app.SetTestClient(tc.client)
+			r, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			r.Header.Set("X-Forwarded-Host", fmt.Sprintf("%s.example.net", tc.alias))
+			w := httptest.NewRecorder()
+			handler := app.WrapHandler(app.HandleProxy)
+			handler.ServeHTTP(w, r)
+			if e, a := tc.expectCode, w.Code; e != a {
+				t.Errorf("expect %d, got %d", e, a)
+			}
+			if e, a := tc.expectBody, w.Body.String(); e != a {
+				t.Errorf("expect %s, got %s", e, a)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When calling a non-existent Lambda function, the following message is returned in the response:  

```
operation error Lambda: Invoke, https response error StatusCode: 404, RequestID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, ResourceNotFoundException: Function not found: arn:aws:lambda:ap-northeast-1:999999999999:function:xxxxxx:current
```  

I thought it would be good if errors occurring in Lamux could be logged but hidden from the response, so I added an option for that.  

What do you think?