### PR TITLE
Add --log-level flag and LAMUX_LOG_LEVEL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Flags:
       --function-name="*"                 Name of the Lambda function to proxy ($LAMUX_FUNCTION_NAME)
       --domain-suffix="localdomain"       Domain suffix to accept requests for ($LAMUX_DOMAIN_SUFFIX)
       --upstream-timeout=30s              Timeout for upstream requests ($LAMUX_UPSTREAM_TIMEOUT)
+      --log-level="INFO"                  Log level (DEBUG, INFO, WARN, ERROR) ($LAMUX_LOG_LEVEL)
       --version                           Show version information
       --trace-insecure                    Disable TLS for Otel trace endpoint ($OTEL_EXPORTER_OTLP_INSECURE)
       --trace-protocol="http/protobuf"    Otel trace protocol ($OTEL_EXPORTER_OTLP_PROTOCOL)
@@ -162,6 +163,13 @@ Timeout for upstream requests. Default is `30s`.
 
 This setting is affected by the Lambda function timeout. If the Lambda function timeout is less than the `--upstream-timeout`, it will time out before the `--upstream-timeout`.
 
+### `--log-level` (`$LAMUX_LOG_LEVEL`)
+
+Log level for the application. Default is `INFO`.
+
+Available levels: `DEBUG`, `INFO`, `WARN`, `ERROR`.
+
+For example, setting `LAMUX_LOG_LEVEL=WARN` suppresses Info-level access logs (`handleProxy`, `response`) and only outputs Warn/Error-level logs.
 
 ### OpenTelemetry tracing support
 

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	FunctionName    string        `help:"Name of the Lambda function to proxy" default:"*" env:"LAMUX_FUNCTION_NAME" name:"function-name"`
 	DomainSuffix    string        `help:"Domain suffix to accept requests for" default:"localdomain" env:"LAMUX_DOMAIN_SUFFIX" name:"domain-suffix"`
 	UpstreamTimeout time.Duration `help:"Timeout for upstream requests" default:"30s" env:"LAMUX_UPSTREAM_TIMEOUT" name:"upstream-timeout"`
+	LogLevel        string        `help:"Log level (DEBUG, INFO, WARN, ERROR)" default:"INFO" env:"LAMUX_LOG_LEVEL" name:"log-level"`
 	Version         bool          `help:"Show version information" name:"version"`
 
 	TraceConfig

--- a/lamux.go
+++ b/lamux.go
@@ -75,10 +75,16 @@ func newHandlerError(err error, code int) *HandlerError {
 }
 
 func Run(ctx context.Context) error {
-	slog.SetDefault(slog.New(slogcontext.NewHandler(slog.NewJSONHandler(os.Stdout, nil))))
-
 	cfg := &Config{}
 	kong.Parse(cfg)
+
+	var logLevel slog.Level
+	if err := logLevel.UnmarshalText([]byte(cfg.LogLevel)); err != nil {
+		return fmt.Errorf("invalid log level %q: %w", cfg.LogLevel, err)
+	}
+	slog.SetDefault(slog.New(slogcontext.NewHandler(
+		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}),
+	)))
 	if cfg.Version {
 		fmt.Println(Version)
 		return nil


### PR DESCRIPTION
## Summary

Add a `--log-level` flag (`LAMUX_LOG_LEVEL` environment variable) to control the slog output level.

Currently, lamux has no way to control log verbosity. The slog handler is initialized with `nil` options, so the log level is always `INFO`. This means Info-level access logs (`handleProxy`, `response`) cannot be suppressed.

## Changes

- Add `LogLevel` field to `Config` struct with kong tags (`--log-level` / `LAMUX_LOG_LEVEL`, default: `INFO`)
- Parse the log level string via `slog.Level.UnmarshalText()` and pass it to `slog.HandlerOptions{Level: logLevel}`
- Move slog initialization after `kong.Parse()` so the config value is available
- Update README.md (usage and configuration sections)

## Motivation

When lamux runs as a Lambda extension, Info-level access logs can account for a significant portion of CloudWatch Logs output. By setting `LAMUX_LOG_LEVEL=WARN`, users can suppress these access logs while retaining Error/Warn-level logs, reducing log volume and cost.

## Usage

```console
# via environment variable
LAMUX_LOG_LEVEL=WARN lamux

# via CLI flag
lamux --log-level=WARN
```

Available levels: `DEBUG`, `INFO` (default), `WARN`, `ERROR`