### PR TITLE
Support immutable release with tagpr draft + goreleaser

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
-          version: latest
+          version: '~> v2'
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -13,10 +14,11 @@ builds:
     goarch:
       - amd64
       - arm64
+release:
+  prerelease: "true"
+  use_existing_draft: true
 checksum:
   name_template: "checksums.txt"
-snapshot:
-  name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/.tagpr
+++ b/.tagpr
@@ -40,3 +40,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = -
+	release = draft


### PR DESCRIPTION
## Summary
- Configure tagpr to create draft releases (`release = draft` in .tagpr)
- Configure goreleaser to use existing draft releases (`use_existing_draft: true`, `prerelease: "true"`)
- Update goreleaser to v2 config format and pin goreleaser-action version to `~> v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)